### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM tozd/meteor
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+mongodb:
+  image: tozd/meteor-mongodb:2.6
+  environment:
+    MONGODB_ADMIN_PWD: jvkcWfymeivM3ZBZ
+    MONGODB_CREATE_PWD: jvkcWfymeivM3ZBZ
+    MONGODB_OPLOGGER_PWD: jvkcWfymeivM3ZBZ
+meteor:
+  build: .
+  environment:
+    ROOT_URL: "http://localhost"
+    MONGO_URL: "mongodb://meteor:jvkcWfymeivM3ZBZ@mongodb/meteor"
+    MONGO_OPLOG_URL: "mongodb://oplogger:jvkcWfymeivM3ZBZ@mongodb/local?authSource=admin"
+  ports:
+    - "3000:3000"
+  links:
+    - mongodb
+

--- a/docker-source.sh
+++ b/docker-source.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt-get --yes --force-yes install libzmq3 libzmq3-dev
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "map",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/djelenc/map.git"
+  },
+  "author": "",
+  "license": "",
+  "bugs": {
+    "url": "https://github.com/djelenc/map/issues"
+  },
+  "homepage": "https://github.com/djelenc/map",
+  "dependencies": {
+    "zmq": "2.8.0"
+  }
+}


### PR DESCRIPTION
Can be used with `docker-compose` to also run MongoDB in a container (see [documentation](https://docs.docker.com/compose/) for installation instructions). To run Meteor and MongoDB, just do:

```
docker-compose up
```

Container configuration is in `docker-compose.yml`.
